### PR TITLE
Add PyPI publishing to release workflow (closes #9, closes #3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,12 +26,50 @@ jobs:
         run: uv sync
 
       - name: Lint
-        run: uv run ruff check src/ tests/
+        run: uv run ruff check src/ tests/ scripts/
 
       - name: Test
         run: uv run pytest --cov=good_egg -v
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+
+      - name: Update major version tag
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          MAJOR=$(echo "$TAG" | grep -oP '^v\d+')
+          git tag -f "$MAJOR" "$TAG"
+          git push origin "$MAJOR" --force

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,13 @@ description = "Trust scoring for GitHub contributors using graph-based ranking o
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.12"
+keywords = ["github", "trust", "security", "pull-request", "code-review"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Quality Assurance",
+]
 dependencies = [
     "httpx>=0.27",
     "networkx>=3.2",
@@ -14,10 +21,17 @@ dependencies = [
     "pydantic>=2.5",
     "pyyaml>=6.0",
     "tenacity>=8.2",
+    "mcp>=1.0",
 ]
 
 [project.scripts]
 good-egg = "good_egg.cli:main"
+good-egg-mcp = "good_egg.mcp_server:main"
+
+[project.urls]
+Homepage = "https://github.com/2ndSetAI/good-egg"
+Repository = "https://github.com/2ndSetAI/good-egg"
+Issues = "https://github.com/2ndSetAI/good-egg/issues"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary

- Replace single-job release workflow with a 3-job pipeline: **test** (lint + tests), **publish** (build + PyPI trusted publishing), and **release** (GitHub Release + major version tag update)
- Add PyPI metadata to `pyproject.toml`: keywords, classifiers, and project URLs

## Test plan

- [x] All 193 existing tests pass
- [x] Ruff lint passes (no new issues introduced)
- [ ] Verify PyPI trusted publishing works on next tag push
- [ ] Verify GitHub Release is created with auto-generated notes

Closes #9, closes #3