### PR TITLE
Add PyPI publishing to release workflow (closes #9, closes #3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,11 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
-
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -70,6 +69,6 @@ jobs:
       - name: Update major version tag
         run: |
           TAG=${GITHUB_REF#refs/tags/}
-          MAJOR=$(echo "$TAG" | grep -oP '^v\d+')
+          MAJOR=${TAG%%.*}
           git tag -f "$MAJOR" "$TAG"
           git push origin "$MAJOR" --force

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,11 @@ requires-python = ">=3.12"
 keywords = ["github", "trust", "security", "pull-request", "code-review"]
 classifiers = [
     "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.12",
+    "Topic :: Security",
     "Topic :: Software Development :: Quality Assurance",
 ]
 dependencies = [


### PR DESCRIPTION
## Summary

- Replace single-job release workflow with a 3-job pipeline: **test** (lint + tests), **publish** (build + PyPI via OIDC trusted publishing), and **release** (GitHub Release + major version tag update)
- Add `scripts/` to the lint step
- Add PyPI metadata to `pyproject.toml`: keywords, classifiers, and project URLs

Closes #9, closes #3

## Test plan

- [ ] Verify PyPI trusted publishing works on next tag push (requires human setup: PyPI project, trusted publisher config, GitHub `pypi` environment)
- [ ] Verify GitHub Release is created with auto-generated notes
- [ ] Verify floating `v1` tag is updated