### PR TITLE
Fix composite action: hatch-vcs fallback version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,8 @@ runs:
 
     - name: Install good-egg
       shell: bash
+      env:
+        SETUPTOOLS_SCM_PRETEND_VERSION: '0.0.0'
       run: |
         cd ${{ github.action_path }}
         uv sync --frozen


### PR DESCRIPTION
## Summary

The switch to hatch-vcs dynamic versioning (#18) broke the composite action. GitHub downloads action code as a tarball without `.git` history, so `hatch-vcs` / `setuptools-scm` can't resolve the version during `uv sync`.

Fix: set `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0` in the install step. The version doesn't matter at runtime since `__init__.py` uses `importlib.metadata.version()` from the installed package, not from the build.

## Test plan

- [ ] Merge this, then re-trigger the Good Egg workflow on PR #19 to verify the action runs successfully