### PR TITLE
Fix action: reject directory paths as config-path input

### DIFF
--- a/src/good_egg/action.py
+++ b/src/good_egg/action.py
@@ -32,8 +32,11 @@ async def run_action() -> None:
 
     # Read action inputs (GitHub Actions sets INPUT_ env vars)
     config_path = os.environ.get("INPUT_CONFIG-PATH") or os.environ.get("INPUT_CONFIG_PATH")
-    if config_path and not os.path.exists(config_path):
-        logger.warning("Config file %s not found, using defaults", config_path)
+    if config_path and not os.path.isfile(config_path):
+        if os.path.exists(config_path):
+            logger.warning("Config path %s is not a file, using defaults", config_path)
+        else:
+            logger.warning("Config file %s not found, using defaults", config_path)
         config_path = None
     should_comment = os.environ.get("INPUT_COMMENT", "true").lower() == "true"
     should_check_run = os.environ.get("INPUT_CHECK-RUN", "false").lower() == "true"


### PR DESCRIPTION
## Summary

The composite action crashes with `IsADirectoryError` when `config-path` is not provided. The config path validation used `os.path.exists()`, which returns `True` for directories. When the action resolves the input to `"."` (current directory), it passes validation and then `open(".")` fails.

Fix: use `os.path.isfile()` instead of `os.path.exists()` so directories are rejected and the action falls back to defaults.

## Test plan

- [x] `test_action.py` -- 10 tests pass
- [ ] Merge this, then retrigger PR #19 to verify the action runs end-to-end