### PR TITLE
Fix config: reject directory paths in load_config

### DIFF
--- a/src/good_egg/config.py
+++ b/src/good_egg/config.py
@@ -145,7 +145,7 @@ def load_config(path: str | Path | None = None) -> GoodEggConfig:
         # Try default locations
         for default_path in [".good-egg.yml", ".good-egg.yaml"]:
             p = Path(default_path)
-            if p.exists():
+            if p.is_file():
                 with open(p) as f:
                     yaml_data = yaml.safe_load(f)
                     if yaml_data:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -79,6 +79,11 @@ class TestLoadConfig:
         config = load_config(tmp_path / "nonexistent.yml")
         assert config.graph_scoring.alpha == 0.85
 
+    def test_load_directory_path_falls_back_to_defaults(self, tmp_path: Path) -> None:
+        config = load_config(tmp_path)
+        assert isinstance(config, GoodEggConfig)
+        assert config.graph_scoring.alpha == 0.85
+
     def test_env_var_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("GOOD_EGG_ALPHA", "0.9")
         config = load_config()


### PR DESCRIPTION
## Summary

Belt-and-suspenders fix for the `IsADirectoryError` crash. PR #21 added an `isfile()` guard in `action.py`, but the crash persists because `config.py:load_config()` also uses `exists()` which returns True for directories.

One-line fix: `config_path.exists()` → `config_path.is_file()` in `load_config()`.

## Test plan

- [x] 26 config + action tests pass
- [ ] Merge, retrigger PR #19