### PR TITLE
Add uvx quick-start example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ instead of requiring manual vouching. See
 Try Good Egg without installing anything (requires [uv](https://docs.astral.sh/uv/)):
 
 ```bash
-export GITHUB_TOKEN=ghp_...
-uvx good-egg score jeffreyksmithjr --repo=jeffreyksmithjr/good-egg
+# Requires a GitHub personal access token
+GITHUB_TOKEN=<token> uvx good-egg score <username> --repo <owner/repo>
 ```
 
 This runs Good Egg in a temporary environment with no install needed.


### PR DESCRIPTION
## Summary

- Add a **Quick Start** section showing `uvx` as a zero-install way to try Good Egg
- Add a `uvx` alternative in the **Installation** section alongside existing `pip install` commands

## Motivation

`uvx good-egg score <user> --repo <owner/repo>` works out of the box from PyPI and is a much lower friction entry point than `pip install`. This makes it easier for people to try Good Egg without committing to an install.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm `uvx good-egg --help` works from a clean environment
- [ ] Confirm `GITHUB_TOKEN=... uvx good-egg score jeffreyksmithjr --repo=jeffreyksmithjr/good-egg` produces a score