### PR TITLE
Fix crash on null repository in PR history

### DIFF
--- a/src/good_egg/github_client.py
+++ b/src/good_egg/github_client.py
@@ -267,6 +267,8 @@ class GitHubClient:
                 if len(prs) >= max_prs:
                     break
                 repo = node["repository"]  # type: ignore[index]
+                if repo is None:
+                    continue
                 prs.append(
                     MergedPR(
                         repo_name_with_owner=repo["nameWithOwner"],
@@ -434,6 +436,8 @@ class GitHubClient:
             if len(prs) >= max_prs:
                 break
             repo = node["repository"]  # type: ignore[index]
+            if repo is None:
+                continue
             repo_name = repo["nameWithOwner"]
             prs.append(
                 MergedPR(
@@ -471,6 +475,8 @@ class GitHubClient:
                 if len(prs) >= max_prs:
                     break
                 repo = node["repository"]  # type: ignore[index]
+                if repo is None:
+                    continue
                 repo_name = repo["nameWithOwner"]
                 prs.append(
                     MergedPR(


### PR DESCRIPTION
## Summary
- Fix `TypeError: 'NoneType' object is not subscriptable` when a user's PR history includes PRs to deleted or inaccessible repositories (#28)
- The GitHub GraphQL API returns `null` for the `repository` field on such PR nodes; we now skip them gracefully in all three PR-parsing loops in `github_client.py`
- Added tests covering the null-repository scenario for both `fetch_user_merged_prs` and `get_user_contribution_data`

## Test plan
- [x] All 221 tests pass (including 2 new tests for this fix)
- [x] 92% coverage maintained
- [x] Lint (`ruff`) and type check (`mypy`) clean
- [x] Verified live: `good-egg score Kroppeb --repo 2ndSetAI/good-egg` now returns `HIGH (81%)` instead of crashing

Fixes #28