### PR TITLE
Point action ref to @v1 for release

### DIFF
--- a/.github/workflows/good-egg.yml
+++ b/.github/workflows/good-egg.yml
@@ -11,7 +11,7 @@ jobs:
   score:
     runs-on: ubuntu-latest
     steps:
-      - uses: 2ndSetAI/good-egg@better-egg
+      - uses: 2ndSetAI/good-egg@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           scoring-model: v2


### PR DESCRIPTION
One-line change: update the Good Egg CI workflow to reference `@v1` instead of `@better-egg` (the temporary branch ref used for self-testing during PR #31).

This must merge before tagging v1.0.0 so the release workflow creates the `@v1` tag that this ref points to.