### PR TITLE
Remove unused percentile from TrustScore

### DIFF
--- a/docs/library.md
+++ b/docs/library.md
@@ -179,7 +179,6 @@ the following fields:
 | `raw_score` | `float` | Raw graph score before normalization |
 | `normalized_score` | `float` | Normalized score (0.0 - 1.0) |
 | `trust_level` | `TrustLevel` | HIGH, MEDIUM, LOW, UNKNOWN, BOT, or EXISTING_CONTRIBUTOR |
-| `percentile` | `float` | Percentile rank (0.0 - 1.0) |
 | `account_age_days` | `int` | Age of the GitHub account in days |
 | `total_merged_prs` | `int` | Total number of merged pull requests |
 | `unique_repos_contributed` | `int` | Number of distinct repositories |

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -86,7 +86,7 @@ Returns the full trust score as JSON, including all fields from the
 | `force_score` | `boolean` | No | Force full scoring even for known contributors (default: `false`) |
 
 **Returns:** Full `TrustScore` JSON with all fields (user_login,
-context_repo, raw_score, normalized_score, trust_level, percentile,
+context_repo, raw_score, normalized_score, trust_level,
 account_age_days, total_merged_prs, unique_repos_contributed,
 top_contributions, language_match, flags, scoring_model, component_scores,
 scoring_metadata). When `scoring_model` is `v2`, the response includes

--- a/src/good_egg/models.py
+++ b/src/good_egg/models.py
@@ -84,7 +84,7 @@ class TrustScore(BaseModel):
     raw_score: float = 0.0
     normalized_score: float = 0.0
     trust_level: TrustLevel = TrustLevel.UNKNOWN
-    percentile: float = 0.0
+
     account_age_days: int = 0
     total_merged_prs: int = 0
     unique_repos_contributed: int = 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,7 +149,7 @@ def sample_trust_score() -> TrustScore:
         raw_score=0.0045,
         normalized_score=0.72,
         trust_level=TrustLevel.HIGH,
-        percentile=85.0,
+
         account_age_days=1800,
         total_merged_prs=3,
         unique_repos_contributed=3,
@@ -186,7 +186,7 @@ def sample_v2_trust_score() -> TrustScore:
         raw_score=0.0045,
         normalized_score=0.72,
         trust_level=TrustLevel.HIGH,
-        percentile=85.0,
+
         account_age_days=1800,
         total_merged_prs=3,
         unique_repos_contributed=3,

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -22,7 +22,7 @@ def _make_score(**kwargs) -> TrustScore:
         "raw_score": 0.65,
         "normalized_score": 0.72,
         "trust_level": TrustLevel.HIGH,
-        "percentile": 85.0,
+
         "account_age_days": 365,
         "total_merged_prs": 42,
         "unique_repos_contributed": 10,
@@ -199,7 +199,7 @@ class TestBetterEggFormatting:
             "raw_score": 0.65,
             "normalized_score": 0.72,
             "trust_level": TrustLevel.HIGH,
-            "percentile": 85.0,
+
             "account_age_days": 1825,
             "total_merged_prs": 42,
             "unique_repos_contributed": 10,


### PR DESCRIPTION
Fixes #34 .
Percentile is part of the the TrustScore model, but it is never computed. This PR removes it from the base model and docs. 

An alternative fix would be to provide the underlying distribution or a lookup table approximation to compute it.

Linting and tests pass