### PR TITLE
Prepare v2.0.0 release: install from PyPI

### DIFF
--- a/.github/workflows/good-egg.yml
+++ b/.github/workflows/good-egg.yml
@@ -11,7 +11,7 @@ jobs:
   score:
     runs-on: ubuntu-latest
     steps:
-      - uses: 2ndSetAI/good-egg@v1
+      - uses: 2ndSetAI/good-egg@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-known-contributors: 'false'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - 2026-03-13
 
 ### Added
 
@@ -61,5 +61,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - YAML configuration with environment variable overrides.
 - Multiple output formatters: Markdown, CLI table, JSON, and GitHub check-run.
 
+[2.0.0]: https://github.com/2ndSetAI/good-egg/releases/tag/v2.0.0
 [1.0.0]: https://github.com/2ndSetAI/good-egg/releases/tag/v1.0.0
 [0.1.0]: https://github.com/2ndSetAI/good-egg/releases/tag/v0.1.0

--- a/action.yml
+++ b/action.yml
@@ -54,16 +54,9 @@ runs:
       with:
         python-version: '3.12'
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v4
-
     - name: Install good-egg
       shell: bash
-      env:
-        SETUPTOOLS_SCM_PRETEND_VERSION: '0.0.0'
-      run: |
-        cd ${{ github.action_path }}
-        uv sync --frozen
+      run: pip install 'good-egg>=2,<3'
 
     - name: Run Good Egg
       id: score
@@ -76,9 +69,7 @@ runs:
         INPUT_FAIL-ON-LOW: ${{ inputs.fail-on-low }}
         INPUT_SCORING_MODEL: ${{ inputs.scoring-model }}
         INPUT_SKIP_KNOWN_CONTRIBUTORS: ${{ inputs.skip-known-contributors }}
-      run: |
-        cd ${{ github.action_path }}
-        uv run python -m good_egg.action
+      run: python -m good_egg.action
 
 branding:
   icon: 'shield'


### PR DESCRIPTION
## Summary

- Switch GitHub Action from source install (`uv sync`) to PyPI package (`pip install 'good-egg>=2,<3'`)
- Update self-test workflow to `@v2`
- Stamp changelog for 2.0.0

## Notes

The `v2.0.0` tag has already been pushed. Once this PR merges, `main` will match the tag. The release workflow triggered by the tag will publish to PyPI, create the GH release, and set the `v2` major version tag.